### PR TITLE
Added prop passing

### DIFF
--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -8,7 +8,7 @@ export default class App extends React.Component {
     return (
       <div>
         <Fork className="right" project={pkgInfo.user + '/' + pkgInfo.name} />
-        <Demo />
+        <Demo testPropPassing = {true} />
       </div>
     );
   }

--- a/src/components/geolocated.js
+++ b/src/components/geolocated.js
@@ -21,7 +21,7 @@ const geolocated = ({
                 isGeolocationAvailable: Boolean(geolocationProvider),
                 isGeolocationEnabled: true, // be optimistic
                 positionError: null,
-                ...props
+                ...props,
             };
 
             if (userDecisionTimeout) {

--- a/src/components/geolocated.js
+++ b/src/components/geolocated.js
@@ -21,6 +21,7 @@ const geolocated = ({
                 isGeolocationAvailable: Boolean(geolocationProvider),
                 isGeolocationEnabled: true, // be optimistic
                 positionError: null,
+                ...props
             };
 
             if (userDecisionTimeout) {


### PR DESCRIPTION
Allow prop passing such that props that are passed from a parent component to the geolocated component are still passed.

Example

<Display><Geolocated passedProp = {true} /></Display>