### PR TITLE
fix markdown formatting for links for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 ## Contributing
 
-This project uses `[semantic-release](https://github.com/semantic-release/semantic-release)`. Please use `[commitizen](https://github.com/commitizen/cz-cli)` when creating commits.
+This project uses [`semantic-release`](https://github.com/semantic-release/semantic-release). Please use [`commitizen`](https://github.com/commitizen/cz-cli) when creating commits.


### PR DESCRIPTION
The links now display as clickable, and still have backtick code formatting.