### PR TITLE
Add an opt-in delayed location query

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ The `geolocated` function takes optional configuration parameter:
         timeout: Infinity,
     },
     userDecisionTimeout: null,
+    suppressLocationOnMount: false,
     geolocationProvider: navigator.geolocation
 }
 ```
@@ -111,6 +112,8 @@ The `positionOptions` object corresponds to the [PositionOptions](https://develo
 If set, the `userDecisionTimeout` determines how much time (in miliseconds) we give the user to make the decision whether to allow to share their location or not.
 In Firefox, if the user declines to use their location, the Geolocation API call does not end with an error.
 Therefore we want to fallback to the error state if the user declines and the API does not tell us.
+
+The location is obtained when the component mounts by default. If you want to prevent this and get the location later, set the `suppressLocationOnMount` to `true` and using a `ref` in the parent component call its `getLocation` method (see the demo's [`App` component](https://github.com/no23reason/react-geolocated/blob/dcbe587880751519a6ac6adaa6c49780b609e3c2/demo/App.jsx#L14-L21) for example of this).
 
 The `geolocationProvider` allows to specify alternative source of the geolocation API. This was added mainly for testing purposes, however feel free to use it if need be.
 

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -4,12 +4,28 @@ import pkgInfo from '../package.json';
 import Demo from './Demo.jsx';
 
 export default class App extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.getInnerRef = this.getInnerRef.bind(this);
+    this.getLocation = this.getLocation.bind(this);
+  }
+
+  innerRef;
+  getInnerRef(ref) {
+    this.innerRef = ref;
+  }
+
+  getLocation() {
+    this.innerRef && this.innerRef.getLocation();
+  }
+
   render() {
-    return (
-      <div>
-        <Fork className="right" project={pkgInfo.user + '/' + pkgInfo.name} />
-        <Demo />
-      </div>
-    );
+    const { getInnerRef, getLocation } = this;
+    return (<div>
+      <Fork className="right" project={pkgInfo.user + '/' + pkgInfo.name} />
+      <Demo ref={getInnerRef} />
+      <button onClick={getLocation}>Get location</button>
+    </div>);
   }
 }

--- a/demo/Demo.jsx
+++ b/demo/Demo.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {geolocated, geoPropTypes} from '../src/index';
+import { geolocated, geoPropTypes } from '../src/index';
 
 const getDirection = (degrees, isLongitude) =>
   degrees > 0
@@ -12,7 +12,7 @@ const formatDegrees = (degrees, isLongitude) =>
 
 class Demo extends React.Component {
   render() {
-    const {props} = this;
+    const { props } = this;
     return !props.isGeolocationAvailable
       ? <div>Your browser does not support Geolocation.</div>
       : !props.isGeolocationEnabled
@@ -30,7 +30,7 @@ class Demo extends React.Component {
   }
 }
 
-Demo.propTypes = {...Demo.propTypes, ...geoPropTypes };
+Demo.propTypes = { ...Demo.propTypes, ...geoPropTypes };
 
 export default geolocated({
   positionOptions: {

--- a/src/components/geolocated.js
+++ b/src/components/geolocated.js
@@ -12,6 +12,7 @@ const geolocated = ({
         timeout: Infinity,
     },
     userDecisionTimeout = null,
+    suppressLocationOnMount = false,
     geolocationProvider = (typeof (navigator) !== 'undefined' && navigator.geolocation),
 } = {}) => (WrappedComponent) => {
     let result = class Geolocated extends Component {
@@ -33,6 +34,7 @@ const geolocated = ({
             this.onPositionError = this.onPositionError.bind(this);
             this.onPositionSuccess = this.onPositionSuccess.bind(this);
             this.cancelUserDecisionTimeout = this.cancelUserDecisionTimeout.bind(this);
+            this.getLocation = this.getLocation.bind(this);
         }
 
         cancelUserDecisionTimeout() {
@@ -61,11 +63,17 @@ const geolocated = ({
             });
         }
 
-        componentDidMount() {
+        getLocation() {
             if (!geolocationProvider || !geolocationProvider.getCurrentPosition) {
                 throw new Error('The provided geolocation provider is invalid');
             }
             geolocationProvider.getCurrentPosition(this.onPositionSuccess, this.onPositionError, positionOptions);
+        }
+
+        componentDidMount() {
+            if (!suppressLocationOnMount){
+                this.getLocation();
+            }
         }
 
         componentWillUnmount() {


### PR DESCRIPTION
As discussed in #155 this PR adds an option to not query the location on component mount and exposes the `getLocation` method to be used using `ref`.

Closes #155 