### PR TITLE
feat(component): add support for watchPosition()

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,15 @@ The `geolocated` function takes optional configuration parameter:
         maximumAge: 0,
         timeout: Infinity,
     },
+    watchPosition: false,
     userDecisionTimeout: null,
     suppressLocationOnMount: false,
     geolocationProvider: navigator.geolocation
 }
 ```
 The `positionOptions` object corresponds to the [PositionOptions](https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions) of the Geolocation API.
+
+By default the component only sets position once.  To watch the user's position and provide live updates to position, set `watchPosition = true`.  The geolocation event handler is unregistered when the component unmounts.
 
 If set, the `userDecisionTimeout` determines how much time (in miliseconds) we give the user to make the decision whether to allow to share their location or not.
 In Firefox, if the user declines to use their location, the Geolocation API call does not end with an error.

--- a/tests/geolocated.test.js
+++ b/tests/geolocated.test.js
@@ -30,12 +30,23 @@ const mockSuccessfulGeolocationProvider = {
         latitude: 50,
         longitude: 20,
       },
-    })
+    });
+  },
+  watchPosition(onSuccess) {
+    return onSuccess({
+      coords: {
+        latitude: 50,
+        longitude: 20,
+      },
+    });
   },
 };
 
 const mockNoopGeolocationProvider = {
   getCurrentPosition() {
+    return;
+  },
+  watchPosition() {
     return;
   },
 };


### PR DESCRIPTION
Was bored this afternoon, implemented the feature I requested in #170.  I did my best to follow your contribution guideline: please let me know if anything's amiss and I'll happily fix it.  

Add support for geolocation.watchPosition() method, updating state on each location change and
remove watcher on component unmount.

impl #170