### PR TITLE
fix: save reference to position watch

### DIFF
--- a/src/components/geolocated.js
+++ b/src/components/geolocated.js
@@ -89,7 +89,7 @@ const geolocated = ({
                 }, userDecisionTimeout);
             }
 
-            funcPosition(
+            this.watchId = funcPosition(
                 this.onPositionSuccess,
                 this.onPositionError,
                 positionOptions,


### PR DESCRIPTION
The reference to the watch position watchId was not properly stored.
This prevented us from properly cleaning up.

Fixes #183 
Closes #184 