### PR TITLE
feat: allow React 17 as peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "typings-tester": "^0.3.2"
     },
     "peerDependencies": {
-        "react": ">= 0.11.2 < 17.0.0"
+        "react": ">= 0.11.2 < 18.0.0"
     },
     "dependencies": {
         "prop-types": "^15.5.8"


### PR DESCRIPTION
React 17 was released recently and can be allowed in the peerDependencies to avoid warnings when requiring react-geolocated in a React 17 project.
