### PR TITLE
feat: add timestamp prop to the wrapped component

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The props passed to the wrapped component are:
         heading,
         speed,
     },
+    timestamp, // timestamp of when the last position was retrieved
     isGeolocationAvailable, // boolean flag indicating that the browser supports the Geolocation API
     isGeolocationEnabled, // boolean flag indicating that the user has allowed the use of the Geolocation API
     positionError, // object with the error returned from the Geolocation API call
@@ -167,7 +168,7 @@ class Demo extends React.Component<IDemoProps & GeolocatedProps> {
         return (
             <div>
                 label: {this.props.label}
-                lattitude: {this.props.coords && this.props.coords.latitude}
+                latitude: {this.props.coords && this.props.coords.latitude}
             </div>
         );
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,10 @@ interface GeolocatedProps {
      */
     coords?: Coordinates;
     /**
+     * The Geolocation API's timestamp value representing the time at which the location was retrieved.
+     */
+    timestamp?: DOMTimeStamp;
+    /**
      * Flag indicating that the browser supports the Geolocation API.
      */
     isGeolocationAvailable?: boolean;

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ export const geolocated = ({
 
         state = {
             coords: null,
+            timestamp: null,
             isGeolocationAvailable: Boolean(geolocationProvider),
             isGeolocationEnabled: isOptimisticGeolocationEnabled,
             positionError: null,
@@ -54,6 +55,7 @@ export const geolocated = ({
             if (this.isCurrentlyMounted) {
                 this.setState({
                     coords: position.coords,
+                    timestamp: position.timestamp,
                     isGeolocationEnabled: true,
                     positionError: null,
                 });
@@ -127,6 +129,7 @@ export const geoPropTypes = {
         heading: PropTypes.number,
         speed: PropTypes.number,
     }),
+    timestamp: PropTypes.number,
     isGeolocationAvailable: PropTypes.bool,
     isGeolocationEnabled: PropTypes.bool,
     positionError: PropTypes.shape({

--- a/tests/typescript/index.tsx
+++ b/tests/typescript/index.tsx
@@ -24,6 +24,8 @@ const StatelessDemo: React.FC<GeolocatedProps> = (props) => (
         isGeolocationAvailable: {props.isGeolocationAvailable}
         isGeolocationEnabled: {props.isGeolocationEnabled}
         positionError: {props.positionError}
+        coords: {props.coords}
+        timestamp: {props.timestamp}
     </div>
 );
 


### PR DESCRIPTION
Adds support for the Geolocation API timestamp property and passes it to the wrapped component.

Fixes #734