### PR TITLE
fix: reference the correct function in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ By default the component only sets position once. To watch the user's position a
 
 If set, the `userDecisionTimeout` determines how much time (in milliseconds) we give the user to make the decision whether to allow to share their location or not. In Firefox, if the user declines to use their location, the Geolocation API call does not end with an error. Therefore we want to fallback to the error state if the user declines and the API does not tell us.
 
-The location is obtained when the component mounts by default. If you want to prevent this and get the location later, set the `suppressLocationOnMount` to `true` and use the `getLocation` function returned by the hook to trigger the geolocation query manually.
+The location is obtained when the component mounts by default. If you want to prevent this and get the location later, set the `suppressLocationOnMount` to `true` and use the `getPosition` function returned by the hook to trigger the geolocation query manually.
 
 The `geolocationProvider` allows to specify alternative source of the geolocation API. This was added mainly for testing purposes, however feel free to use it if need be.
 


### PR DESCRIPTION
The function returned is called `getPosition` not `getLocation`.

Fixes #1374