### PR TITLE
chore: group related dependencies in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,56 +6,15 @@ updates:
     interval: weekly
     time: "04:00"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: gatsby-plugin-mdx
-    versions:
-    - 1.10.1
-    - 2.0.0
-    - 2.0.1
-    - 2.1.0
-    - 2.2.0
-  - dependency-name: "@babel/core"
-    versions:
-    - 7.12.13
-    - 7.12.16
-    - 7.12.17
-    - 7.13.1
-    - 7.13.14
-    - 7.13.8
-  - dependency-name: husky
-    versions:
-    - 5.0.9
-    - 5.1.0
-    - 5.1.2
-    - 5.1.3
-    - 5.2.0
-    - 6.0.0
-  - dependency-name: "@babel/plugin-proposal-object-rest-spread"
-    versions:
-    - 7.12.13
-    - 7.13.0
-    - 7.13.8
-  - dependency-name: "@babel/plugin-proposal-class-properties"
-    versions:
-    - 7.13.0
-  - dependency-name: "@babel/preset-env"
-    versions:
-    - 7.12.13
-    - 7.12.16
-    - 7.13.10
-  - dependency-name: semantic-release
-    versions:
-    - 17.4.0
-    - 17.4.1
-  - dependency-name: eslint
-    versions:
-    - 7.21.0
-  - dependency-name: "@babel/cli"
-    versions:
-    - 7.12.13
-    - 7.12.16
-    - 7.13.0
-  - dependency-name: "@babel/plugin-transform-destructuring"
-    versions:
-    - 7.12.13
-    - 7.13.0
+  groups:
+    eslint:
+      patterns:
+        - "@eslint/*"
+        - "@typescript-eslint/*"
+        - "eslint-*"
+        - "eslint"
+        - "typescript-eslint"
+    tailwind:
+      patterns:
+        - "@tailwindcss/*"
+        - "tailwindcss"


### PR DESCRIPTION
This makes all the eslint stuff be upgraded in a single PR (and similar to that, tailwindcss).
Also remove some obsolete ignore settings.