### PR TITLE
build: add explicit permissions to CI

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
The nodejs.yml file did not have explicit permissions which is not recommended.