### PR TITLE
chore: remove useless default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ export function useGeolocated(config: GeolocatedConfig = {}): GeolocatedResult {
             timeout: Infinity,
         },
         isOptimisticGeolocationEnabled = true,
-        userDecisionTimeout = undefined,
+        userDecisionTimeout,
         suppressLocationOnMount = false,
         watchPosition = false,
         geolocationProvider = typeof navigator !== "undefined"


### PR DESCRIPTION
Putting undefined as a default is a noop, remove it.