### PR TITLE
chore: correct hemisphere letter for negative coords in demo

### DIFF
--- a/demo/Demo.tsx
+++ b/demo/Demo.tsx
@@ -5,13 +5,13 @@ const getDirection = (degrees: number, isLongitude: boolean) =>
     degrees > 0 ? (isLongitude ? "E" : "N") : isLongitude ? "W" : "S";
 
 // adapted from http://stackoverflow.com/a/5786281/2546338
-const formatDegrees = (degrees: number, isLongitude: boolean) =>
-    `${0 | degrees}° ${
-        0 | (((degrees < 0 ? (degrees = -degrees) : degrees) % 1) * 60)
-    }' ${0 | (((degrees * 60) % 1) * 60)}" ${getDirection(
-        degrees,
-        isLongitude,
-    )}`;
+const formatDegrees = (value: number, isLongitude: boolean) => {
+    const abs = Math.abs(value);
+    const degrees = Math.trunc(value);
+    const minutes = Math.floor((abs % 1) * 60);
+    const seconds = Math.floor(((abs * 60) % 1) * 60);
+    return `${degrees}° ${minutes}' ${seconds}" ${getDirection(value, isLongitude)}`;
+};
 
 export const Demo = () => {
     const {


### PR DESCRIPTION
## Summary

Cleans up `formatDegrees` in the demo and fixes a latent bug it was hiding.

The old one-liner mutated its parameter mid-expression (`degrees = -degrees`) to take the absolute value for the minutes calc. Because `getDirection(degrees, …)` is evaluated **last** in the template string, it saw the already-mutated (positive) value — so **every negative coordinate rendered E/N** regardless of hemisphere.

Rewritten with `Math.abs` / `Math.trunc` / `Math.floor` (no mutation, no `0 | x` floor hacks) and `getDirection` now receives the original signed value.

## Effect

Degrees/minutes/seconds are byte-for-byte identical (verified across positive and negative samples). Only the direction letter changes — and only for negatives, where it was wrong:

| input | before | after |
|---|---|---|
| `-122.6789` (lon) | `-122° 40' 44" E` ❌ | `-122° 40' 44" W` ✅ |
| `-20.123` (lat) | `-20° 7' 22" N` ❌ | `-20° 7' 22" S` ✅ |

## Verification
- `npm run docs:build` → clean
- `npm test` → 4/4 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)